### PR TITLE
Fix Python workflow to handle repositories with no Python packages

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,6 +25,7 @@ jobs:
 
   build:
     needs: [detect-packages]
+    if: needs.detect-packages.outputs.packages != '[]'
     strategy:
       matrix:
         package: ${{ fromJson(needs.detect-packages.outputs.packages) }}
@@ -62,7 +63,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build, detect-packages]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && needs.detect-packages.outputs.packages != '[]'
 
     strategy:
       matrix:


### PR DESCRIPTION
- Added conditional checks to skip build and publish jobs when no Python packages exist
- Prevents "Matrix vector 'package' does not contain any values" error
- Workflow now gracefully handles the absence of Python-based servers

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: <!-- e.g., filesystem, github -->
- Changes to: <!-- e.g., tools, resources, prompts -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
